### PR TITLE
Prevent duplicates

### DIFF
--- a/src/app/modules/checkin/pages/checkin-groups/checkin-groups.component.html
+++ b/src/app/modules/checkin/pages/checkin-groups/checkin-groups.component.html
@@ -48,6 +48,9 @@
   <mat-dialog-content>
 
     <form [formGroup]="createGroupForm" (ngSubmit)="onSubmit()">
+
+      <p [hidden]="!(this.createGroupForm.get('title')?.errors?.groupTitleExistsAlready)" style='color: red'>This name already exists; please choose another one.</p>
+
       <mat-form-field appearance="outline">
         <mat-label>Title of Checkin Group</mat-label>
         <input matInput placeholder="Insert title of checkin group" formControlName="title" required>

--- a/src/app/modules/checkin/pages/checkin-groups/checkin-groups.component.html
+++ b/src/app/modules/checkin/pages/checkin-groups/checkin-groups.component.html
@@ -49,7 +49,7 @@
 
     <form [formGroup]="createGroupForm" (ngSubmit)="onSubmit()">
 
-      <p [hidden]="!(this.createGroupForm.get('title')?.errors?.groupTitleExistsAlready)" style='color: red'>This name already exists; please choose another one.</p>
+      <p [hidden]="!(this.createGroupForm.get('title')?.errors?.titleExistsAlready)" style='color: red'>This name already exists; please choose another one.</p>
 
       <mat-form-field appearance="outline">
         <mat-label>Title of Checkin Group</mat-label>

--- a/src/app/modules/checkin/pages/checkin-groups/checkin-groups.component.ts
+++ b/src/app/modules/checkin/pages/checkin-groups/checkin-groups.component.ts
@@ -122,15 +122,32 @@ export class CheckinGroupComponent implements OnInit {
 
   public onSubmit(): void {
     const group: ICheckinGroup = this.createGroupForm.value;
+    
+    // check for duplicate group members, and notify if duplicates are found; unacceptable
+    const thisGroupTitle = group.title;
+    this.groups$.subscribe({
+      next: (groupsArray: Array<ICheckinGroup>) => {
+        let foundDups: boolean = false;
+        for (const group of groupsArray) {
+          if (thisGroupTitle.trim() === group.title.trim()) {
+            foundDups = true;
+          }
+        }
+        if (foundDups) {
+          alert('A group already exists with this title; please use a different title.');
+          return;
+        }
 
-    if (this.editMode) {
-      group.id = this.currentlyUpdatingGroupId;
-      this.backend.updateGroup(group);
-    } else {
-      this.backend.addGroup(group);
-      this.clearCreationDialog();
-    }
-    this.closeCreationDialog();
+        if (this.editMode) {
+          group.id = this.currentlyUpdatingGroupId;
+          this.backend.updateGroup(group);
+        } else {
+          this.backend.addGroup(group);
+          this.clearCreationDialog();
+        }
+        this.closeCreationDialog();
+      }
+    });
   }
 
   public openCreationDialog(group?: ICheckinGroup, editMode?: boolean): void {

--- a/src/app/modules/checkin/pages/checkin-groups/checkin-groups.component.ts
+++ b/src/app/modules/checkin/pages/checkin-groups/checkin-groups.component.ts
@@ -4,7 +4,7 @@ import { ExpansionTableComponent, IDisplayData } from 'src/app/modules/extra-mat
 import { ICheckinGroup, ICheckinGroupMember, BackendCheckinService, ICheckinModel } from 'src/app/modules/backend';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { MatDialogRef } from '@angular/material/dialog';
-import { FormGroup, FormArray, FormBuilder, AsyncValidatorFn, AbstractControl, ValidationErrors } from '@angular/forms';
+import { FormGroup, FormArray, FormBuilder, AsyncValidatorFn, AbstractControl, ValidationErrors, FormControl } from '@angular/forms';
 import { UtilsService } from 'src/app/modules/extra-material/services/utils/utils.service';
 import { first, map } from 'rxjs/operators';
 
@@ -194,11 +194,11 @@ export class CheckinGroupComponent implements OnInit {
       ? allow
       : [allow];
     
-    return (control: AbstractControl): Observable<ValidationErrors | null> => {
+    return (control: FormControl): Observable<ValidationErrors | null> => {
       const thisValue = control.value.trim();
       return this.groups$.pipe(
         map(groups => !allowedTitles.includes(thisValue) && groups.map(g => g.title).includes(thisValue)
-          ? { groupTitleExistsAlready: true }
+          ? { titleExistsAlready: true }
           : null
         ),
         first()

--- a/src/app/modules/checkin/pages/manage-checkin/manage-checkin.component.html
+++ b/src/app/modules/checkin/pages/manage-checkin/manage-checkin.component.html
@@ -48,6 +48,10 @@
   <mat-dialog-content>
 
     <form [formGroup]="createModelForm" (ngSubmit)="onSubmit()">
+
+      <p [hidden]="!(this.createModelForm.get('title')?.errors?.titleExistsAlready)" style='color: red'>This name already
+        exists; please choose another one.</p>
+
       <mat-form-field appearance="outline">
         <mat-label>Title of Checkin Item</mat-label>
         <input matInput placeholder="Insert title of checkin item" formControlName="title" required>
@@ -59,6 +63,9 @@
           <mat-card-header>
             <mat-card-subtitle>Fields</mat-card-subtitle>
           </mat-card-header>
+          <p [hidden]="this.createModelForm.get('fields')?.errors?.duplicateModelFields == null" style='color: red'>
+            The following names are duplicated, please delete or change: {{ this.createModelForm.get('fields')?.errors?.duplicateModelFields.join(', ') }}
+          </p>
           <div *ngFor="let field of fields.controls; let i = index;">
             <div id='field-box-main-content'>
               <div [formGroupName]="i">

--- a/src/app/modules/checkin/pages/manage-checkin/manage-checkin.component.ts
+++ b/src/app/modules/checkin/pages/manage-checkin/manage-checkin.component.ts
@@ -95,7 +95,7 @@ export class ManageCheckinComponent implements OnInit {
         optional: [field.optional],
         delay: [field.delay],
         groupId: [field.groupId ? (field.groupId as DocumentReference).id : ''],
-      })), { validators: [this.modelFieldsValidator] }),
+      }, { validators: [this.groupIdValidator] })), { validators: [this.modelFieldsValidator] }),
     });
   }
 
@@ -134,7 +134,7 @@ export class ManageCheckinComponent implements OnInit {
       optional: [false],
       delay: [false],
       groupId: ['']
-    });
+    }, { validators: [this.groupIdValidator] });
   }
 
   public confirmDeleteModel(model: ICheckinModel): void {
@@ -148,21 +148,6 @@ export class ManageCheckinComponent implements OnInit {
   }
 
   public onSubmit(): void {
-    // check for empty groupIds where they are required
-    // this is a WORKAROUND. Ideally, groupIds are automatically validated
-    // by Angular Forms as intended. However, that is currently bugged. See ticket
-    const fieldsToScan:any[] = this.fields.value;
-    const missings:string[] = [];
-    fieldsToScan.forEach((obj) => {
-      if (obj.type === 'select'  && obj.groupId.trim().length === 0) {
-        missings.push(obj.title);
-      }
-    });
-    if (missings.length > 0) {
-      alert(`Please enter a groupId for: ${missings.join(', ')}`);
-      return;
-    }
-
     const model: ICheckinModel = this.createModelForm.value;
     if (this.editMode) {
       model.id = this.currentlyUpdatingModelId;
@@ -267,5 +252,17 @@ export class ManageCheckinComponent implements OnInit {
     } else {
       return null;
     }
+  }
+
+  /**
+   * Synchronous validator for use with FormControl's which represent fields. 
+   * Ensures that groupId is required if type is specified. 
+   */
+  public groupIdValidator = (group: FormGroup): ValidationErrors | null => {
+    const thisGroupId = group.get('groupId')?.value;
+    const groupIdIsEmpty = thisGroupId == null || thisGroupId.trim().length === 0;
+    return group.get('type')?.value === 'select' && groupIdIsEmpty
+      ? { groupIdIsNeeded: true }
+      : null;
   }
 }

--- a/src/app/modules/extra-material/services/mat-data/mat-data.service.ts
+++ b/src/app/modules/extra-material/services/mat-data/mat-data.service.ts
@@ -12,9 +12,6 @@ import { startWith } from 'rxjs/operators';
 export class MatDataService {
 
   public compare(a: any, b: any): number {
-    console.log(`read ${a} of type ${typeof a}`);
-    console.log(`read ${b} of type ${typeof b}`);
-    
     a = (a === undefined) ? null : a;
     b = (b === undefined) ? null : b;
     if (a === b) {

--- a/src/app/modules/routes/pages/manage-routes/manage-routes.component.html
+++ b/src/app/modules/routes/pages/manage-routes/manage-routes.component.html
@@ -47,6 +47,10 @@
   </div>
   <mat-dialog-content>
     <form [formGroup]="createRouteForm" (ngSubmit)="onSubmit()">
+
+      <p [hidden]="!(this.createRouteForm.get('title')?.errors?.titleExistsAlready)" style='color: red'>This name already
+        exists; please choose another one.</p>
+
       <mat-form-field appearance="outline">
         <mat-label>Name of Route</mat-label>
         <input matInput placeholder="Insert name of route" formControlName="title" required>
@@ -59,6 +63,9 @@
           <mat-card-header>
             <mat-card-subtitle>Fields</mat-card-subtitle>
           </mat-card-header>
+          <p [hidden]="this.createRouteForm.get('fields')?.errors?.duplicateFields == null" style='color: red'>
+            The following field names are duplicated, please delete or change: {{ this.createRouteForm.get('fields')?.errors?.duplicateFields.join(', ') }}
+          </p>
           <div *ngFor="let field of fields.controls; let i = index;">
             <div class="field-box-main-content">
               <div [formGroupName]="i">
@@ -121,6 +128,9 @@
           <mat-card-header>
             <mat-card-subtitle>Stops</mat-card-subtitle>
           </mat-card-header>
+          <p [hidden]="this.createRouteForm.get('stops')?.errors?.duplicateFields == null" style='color: red'>
+            The following stop names are duplicated, please delete or change: {{ this.createRouteForm.get('stops')?.errors?.duplicateFields.join(', ') }}
+          </p>
           <div *ngFor="let stop of stops.controls; let i = index;">
             <div class='field-box-main-content'>
               <div [formGroupName]="i">
@@ -176,9 +186,15 @@
           <mat-card-header>
             <mat-card-subtitle>Stop Fields -- applied to every stop</mat-card-subtitle>            
           </mat-card-header>
+          <p [hidden]="this.createRouteForm.get('fields_stops')?.errors?.duplicateFields == null" style='color: red'>
+            The following names are duplicated, please delete or change: {{ this.createRouteForm.get('fields_stops')?.errors?.duplicateFields.join(', ') }}
+          </p>
           <div *ngFor="let field of fields_stops.controls; let i = index;">
             <div class='field-box-main-content'>
               <div [formGroupName]="i">
+                <p [hidden]="this.createRouteForm.get(['fields_stops', i, 'title'])?.errors?.stopFieldHasComma == null" style='color: red'>
+                  Commas are not allowed in stop field names, please remove or replace. 
+                </p>
                 <mat-form-field>
                   <mat-label>Name of Field</mat-label>
                   <input matInput placeholder="Insert name of field" formControlName="title" required>

--- a/src/app/modules/routes/pages/manage-routes/manage-routes.component.ts
+++ b/src/app/modules/routes/pages/manage-routes/manage-routes.component.ts
@@ -234,7 +234,7 @@ export class ManageRoutesComponent implements OnInit {
   public onSubmit(): void {
     // check for empty groupIds where they are required
     // this is a WORKAROUND. Ideally, groupIds are automatically validated
-    // by Angular Forms as intended. However, that is currently bugged. See ticket
+    // by Angular Forms as intended. However, that is currently bugged.
     const missings: string[] = [];
     this.fields.value.forEach((obj:any) => {
       if (obj.type === 'select' && obj.groupId.trim().length === 0) {

--- a/src/app/modules/routes/pages/route-groups/route-groups.component.html
+++ b/src/app/modules/routes/pages/route-groups/route-groups.component.html
@@ -48,6 +48,10 @@
   <mat-dialog-content>
 
     <form [formGroup]="createGroupForm" (ngSubmit)="onSubmit()">
+
+      <p [hidden]="!(this.createGroupForm.get('title')?.errors?.titleExistsAlready)" style='color: red'>This name already
+        exists; please choose another one.</p>
+
       <mat-form-field appearance="outline">
         <mat-label>Title of Route Group</mat-label>
         <input matInput placeholder="Insert title of route group" formControlName="title" required>


### PR DESCRIPTION
- add automatic validation to prevent:
  - groups from having the same title
  - route models from having the same title
  - checkin models from having the same title
  - within a route, model fields from having the same title
  - within a route, stops from having the same title
  - within a route, stop fields from having the same title
  - within a checkin model, fields from having the same title
- make groupId validation (where groupIds must be provided if a field type is "Dropdown") automatic