### PR TITLE
Record retrieval ranges

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -172,7 +172,8 @@ exports.seedCheckinRecords = functions.https.onRequest(async (req, res) => {
   res.json({ result: `Added checkin records with IDs ${writeResults.map(x => x.id).toString()}.` });
 })
 
-const convertDate = (timestampJSON) => new Date(timestampJSON._seconds * 1000);
+// converts a Firebase timestamp to a human-readable string in Eastern Time
+const convertDate = (timestampJSON) => DateTime.fromJSDate(timestampJSON.toDate()).setZone('America/New_York').toLocaleString(DateTime.DATETIME_SHORT);
 
 // since sheet names cannot contain: \ / ? * [ ]. Removes these things.
 const cleanSheetName = (name) => name.replace(/[/\\?*[\]]/g, '');

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -2025,6 +2025,11 @@
         "yallist": "^3.0.2"
       }
     },
+    "luxon": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.25.0.tgz",
+      "integrity": "sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ=="
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",

--- a/functions/package.json
+++ b/functions/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "firebase-admin": "^8.10.0",
     "firebase-functions": "^3.6.1",
+    "luxon": "^1.25.0",
     "xlsx": "^0.16.5"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2802,6 +2802,12 @@
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
+    "@types/luxon": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-1.25.0.tgz",
+      "integrity": "sha512-iIJp2CP6C32gVqI08HIYnzqj55tlLnodIBMCcMf28q9ckqMfMzocCmIzd9JWI/ALLPMUiTkCu1JGv3FFtu6t3g==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -10707,6 +10713,11 @@
       "requires": {
         "es5-ext": "~0.10.2"
       }
+    },
+    "luxon": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.25.0.tgz",
+      "integrity": "sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ=="
     },
     "magic-string": {
       "version": "0.25.4",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@angular/platform-browser-dynamic": "^11.0.5",
     "@angular/router": "^11.0.5",
     "firebase": "^8.2.1",
+    "luxon": "^1.25.0",
     "rxjs": "^6.5.5",
     "tslib": "^2.0.0",
     "zone.js": "^0.10.3"
@@ -35,6 +36,7 @@
     "@angular/language-service": "^11.0.5",
     "@types/jasmine": "~3.6.0",
     "@types/jasminewd2": "~2.0.3",
+    "@types/luxon": "^1.25.0",
     "@types/node": "^12.12.54",
     "codelyzer": "^6.0.0",
     "firebase-tools": "^8.9.2",

--- a/src/app/modules/backend/services/implementations/firebase/checkin/firebase-checkin.service.ts
+++ b/src/app/modules/backend/services/implementations/firebase/checkin/firebase-checkin.service.ts
@@ -10,7 +10,6 @@ import { map } from 'rxjs/operators';
   providedIn: 'root'
 })
 export class FirebaseCheckinService implements IBackendCheckin {
-  private recordsCollection: AngularFirestoreCollection<IFirestoreCheckinRecord>;
   private modelsCollection: AngularFirestoreCollection<ICheckinModel>;
   private groupsCollection: AngularFirestoreCollection<ICheckinGroup>;
 
@@ -19,11 +18,11 @@ export class FirebaseCheckinService implements IBackendCheckin {
   ) {
     this.groupsCollection = this.firestore.collection<ICheckinGroup>('checkin_groups');
     this.modelsCollection = this.firestore.collection<ICheckinModel>('checkin_models');
-    this.recordsCollection = this.firestore.collection<IFirestoreCheckinRecord>('checkin_records');
   }
 
-  public getRecords(): Observable<ICheckinRecord[]> {
-    return this.recordsCollection.valueChanges().pipe(
+  public getRecords(startDate: Date, endDate: Date): Observable<ICheckinRecord[]> {
+    const query = this.firestore.collection<IFirestoreCheckinRecord>('checkin_records', ref => ref.where('checkoutTime', '>', startDate).where('checkoutTime', '<', endDate));
+    return query.valueChanges().pipe(
       map((rawRecords: IFirestoreCheckinRecord[]): ICheckinRecord[] => {
         return rawRecords.map((rawRecord: IFirestoreCheckinRecord): ICheckinRecord => {
           const record: ICheckinRecord = { ...rawRecord } as unknown as ICheckinRecord;

--- a/src/app/modules/backend/services/implementations/firebase/fb-functions/fb-functions.service.ts
+++ b/src/app/modules/backend/services/implementations/firebase/fb-functions/fb-functions.service.ts
@@ -9,24 +9,37 @@ export class FbFunctionsService {
 
   constructor(private authService: AuthService) {}
 
-  async getRouteRecords(): Promise<Response> {
-    const ROUTES_FUNCTION_PATH = `${this.GENERATE_EXCEL_SHEET_URL}/?recordType=route`;
-    const idToken = await this.authService.getIdToken();
-    return fetch(ROUTES_FUNCTION_PATH, {
-      headers: {
-        'Authorization': `Bearer ${idToken}`
-      }
+  async getRouteRecords(rangeStart: Date, rangeEnd: Date): Promise<Response> {
+    const headers = await this.constructHeaders();
+    return fetch(this.constructPath('route', rangeStart, rangeEnd), {
+      headers: headers
     });
   }
 
-  async getCheckinRecords(): Promise<Response> {
-    const CHECKOUT_FUNCTION_PATH = `${this.GENERATE_EXCEL_SHEET_URL}/?recordType=checkin`;
-    const idToken = await this.authService.getIdToken();
-    return fetch(CHECKOUT_FUNCTION_PATH, {
-      headers: {
-        'Authorization': `Bearer ${idToken}`
-      }
+  async getCheckinRecords(rangeStart: Date, rangeEnd: Date): Promise<Response> {
+    const headers = await this.constructHeaders();
+    return fetch(this.constructPath('checkin', rangeStart, rangeEnd), {
+      headers: headers
     });
+  }
+
+  /**
+   * 
+   * @param recordType 'checkin' or 'route'
+   * @param rangeStart Javascript Date object for range start
+   * @param rangeEnd Javascript Date object for range end. Can occur before rangeStart, but most likely nothing will be returned
+   */
+  constructPath(recordType: string, rangeStart: Date, rangeEnd: Date) {
+    const rangeStartUnixString = Math.trunc((rangeStart.getTime() / 1000)).toString();
+    const rangeEndUnixString = Math.trunc((rangeEnd.getTime() / 1000)).toString();
+    return `${this.GENERATE_EXCEL_SHEET_URL}/?recordType=${recordType}&rangeStart=${rangeStartUnixString}&rangeEnd=${rangeEndUnixString}`;
+  }
+
+  async constructHeaders(): Promise<any> {
+    const idToken = await this.authService.getIdToken();
+    return {
+      'Authorization': `Bearer ${idToken}`
+    };
   }
 
 }

--- a/src/app/modules/backend/services/interfaces/checkin/backend-checkin.service.ts
+++ b/src/app/modules/backend/services/interfaces/checkin/backend-checkin.service.ts
@@ -18,7 +18,7 @@ import { AngularFirestore } from '@angular/fire/firestore';
 export abstract class BackendCheckinService implements IBackendCheckin {
   public abstract getGroups(): Observable<ICheckinGroup[]>;
   public abstract getModels(): Observable<ICheckinModel[]>;
-  public abstract getRecords(): Observable<ICheckinRecord[]>;
+  public abstract getRecords(startDate: Date, endDate: Date): Observable<ICheckinRecord[]>;
   public abstract addGroup(group: ICheckinGroup): void;
   public abstract addModel(model: ICheckinModel): void;
   public abstract updateGroup(group: ICheckinGroup): void;

--- a/src/app/modules/backend/services/interfaces/checkin/ibackend-checkin.interface.ts
+++ b/src/app/modules/backend/services/interfaces/checkin/ibackend-checkin.interface.ts
@@ -3,7 +3,7 @@ import { ICheckinRecord, ICheckinModel, ICheckinGroup } from '../../../types';
 
 export interface IBackendCheckin {
   getGroups(): Observable<ICheckinGroup[]>;
-  getRecords(): Observable<ICheckinRecord[]>;
+  getRecords(startDate: Date, endDate: Date): Observable<ICheckinRecord[]>;
   getModels(): Observable<ICheckinModel[]>;
   addGroup(checkin: ICheckinGroup): void;
   addModel(checkin: ICheckinModel): void;

--- a/src/app/modules/checkin/checkin.module.ts
+++ b/src/app/modules/checkin/checkin.module.ts
@@ -16,9 +16,11 @@ import { MatCardModule } from '@angular/material/card';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatDividerModule } from '@angular/material/divider';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ExtraMaterialModule } from '../extra-material';
 import { SharedModule } from '../shared';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
 
 @NgModule({
   declarations: [
@@ -36,6 +38,8 @@ import { SharedModule } from '../shared';
     MatDialogModule,
     MatButtonModule,
     MatCheckboxModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
     MatIconModule,
     MatFormFieldModule,
     MatCardModule,
@@ -44,7 +48,8 @@ import { SharedModule } from '../shared';
     MatDividerModule,
     ReactiveFormsModule,
     ExtraMaterialModule,
-    SharedModule
+    SharedModule,
+    FormsModule
   ]
 })
 export class CheckinModule { }

--- a/src/app/modules/checkin/pages/checkin-records/checkin-records.component.html
+++ b/src/app/modules/checkin/pages/checkin-records/checkin-records.component.html
@@ -1,10 +1,41 @@
-<div id='download-wrapper'>
+<!-- <div id='download-wrapper'>
   <span>You can also download these records as a more detailed Excel-compatible file:</span>
   <button id='download-button' mat-raised-button color="primary" (click)="handleDownload()" [disabled]="disableButton">Download</button>
+</div> -->
+
+<div *ngIf="selectScreen; else elseBlock">
+  <div id='checkin-records-wrapper'>
+    <p>Choose a date range to get records from:</p>
+    <mat-form-field appearance="fill">
+      <mat-label>Start Date - End Date</mat-label>
+      <mat-date-range-input [rangePicker]="picker">
+        <input matStartDate [(ngModel)]="startDate" name="startDate" placeholder="Start date">
+        <input matEndDate [(ngModel)]="endDate" name="endDate" placeholder="End date">
+      </mat-date-range-input>
+      <mat-datepicker-toggle matSuffix [for]="picker">
+        <mat-icon matDatepickerToggleIcon>keyboard_arrow_down</mat-icon>
+      </mat-datepicker-toggle>
+      <mat-date-range-picker #picker></mat-date-range-picker>
+    </mat-form-field>
+  
+    <div>
+      <button mat-raised-button color="primary" (click)="handleViewRecords()" [disabled]="disableButton">View</button>
+    </div>
+    <div>
+      <button mat-raised-button color="primary" (click)="handleDownload()" [disabled]="disableButton">Download</button>
+    </div>
+  </div>
 </div>
-<app-expansion-table [defaultPageSize]="10" [pageSizeOptions]="[5, 10, 25, 50]" [data$]="records$"
-  [displayData]="displayData">
-  <ng-template let-record>
-    <pre>{{ record | json }}</pre>
-  </ng-template>
-</app-expansion-table>
+<ng-template #elseBlock>
+  <div id='table-top'>
+    <button (click)="handleBack()" mat-icon-button aria-label="Close group form" type="button">
+      <mat-icon>keyboard_backspace</mat-icon>
+    </button>
+  </div>
+  <app-expansion-table [defaultPageSize]="10" [pageSizeOptions]="[5, 10, 25, 50]" [data$]="records$"
+    [displayData]="displayData">
+    <ng-template let-record>
+      <pre>{{ record | json }}</pre>
+    </ng-template>
+  </app-expansion-table>
+</ng-template>

--- a/src/app/modules/checkin/pages/checkin-records/checkin-records.component.scss
+++ b/src/app/modules/checkin/pages/checkin-records/checkin-records.component.scss
@@ -1,20 +1,23 @@
 
-#download-button {
-  // font-size: 8px;
-  margin-left: 5px;
+button {
+  font-size: 24px;
 }
 
-#download-wrapper {
-  // padding-top: 20px;
-  // text-align: center;
-  // height: 100%;
-  // overflow-y: hidden;
-  margin: 5px;
-  background-color: white;
-  text-align: right;
+#checkin-records-wrapper {
+  margin: 10px;
+  padding-top: 20px;
+  text-align: center;
 }
 
 #checkin-records-wrapper > p {
   font-size: 16px;
 }
 
+#checkin-records-wrapper button {
+  margin: 5px;
+}
+
+#table-top {
+  margin: 5px;
+  background-color: white;
+}

--- a/src/app/modules/routes/pages/route-records/route-records.component.html
+++ b/src/app/modules/routes/pages/route-records/route-records.component.html
@@ -1,7 +1,7 @@
 <div id='route-records-wrapper'>
-  <p>Select a date range, then download route records as an Excel file.</p>
+  <p>Choose a date range to get records from:</p>
   <mat-form-field appearance="fill">
-    <mat-label>Choose a date range -></mat-label>
+    <mat-label>Start Date - End Date</mat-label>
     <mat-date-range-input [rangePicker]="picker">
       <input matStartDate [(ngModel)]="startDate" name="startDate" placeholder="Start date">
       <input matEndDate [(ngModel)]="endDate" name="endDate" placeholder="End date">

--- a/src/app/modules/routes/pages/route-records/route-records.component.html
+++ b/src/app/modules/routes/pages/route-records/route-records.component.html
@@ -1,17 +1,18 @@
 <div id='route-records-wrapper'>
   <p>Select a date range, then download route records as an Excel file.</p>
-  <!-- <mat-form-field appearance="fill">
+  <mat-form-field appearance="fill">
     <mat-label>Choose a date range -></mat-label>
     <mat-date-range-input [rangePicker]="picker">
       <input matStartDate [(ngModel)]="startDate" name="startDate" placeholder="Start date">
       <input matEndDate [(ngModel)]="endDate" name="endDate" placeholder="End date">
     </mat-date-range-input>
-    TODO try wrapping mat-datepicker-toggle around everything?
     <mat-datepicker-toggle matSuffix [for]="picker">
       <mat-icon matDatepickerToggleIcon>keyboard_arrow_down</mat-icon>
     </mat-datepicker-toggle>
     <mat-date-range-picker #picker></mat-date-range-picker>
-  </mat-form-field> -->
+  </mat-form-field>
 
-  <button mat-raised-button color="primary" (click)="handleDownload()" [disabled]="disableButton">Download</button>
+  <div>
+    <button mat-raised-button color="primary" (click)="handleDownload()" [disabled]="disableButton">Download</button>
+  </div>
 </div>

--- a/src/app/modules/routes/pages/route-records/route-records.component.html
+++ b/src/app/modules/routes/pages/route-records/route-records.component.html
@@ -1,4 +1,17 @@
 <div id='route-records-wrapper'>
-  <p>Click the button below to download route records as an Excel file.</p>
+  <p>Select a date range, then download route records as an Excel file.</p>
+  <!-- <mat-form-field appearance="fill">
+    <mat-label>Choose a date range -></mat-label>
+    <mat-date-range-input [rangePicker]="picker">
+      <input matStartDate [(ngModel)]="startDate" name="startDate" placeholder="Start date">
+      <input matEndDate [(ngModel)]="endDate" name="endDate" placeholder="End date">
+    </mat-date-range-input>
+    TODO try wrapping mat-datepicker-toggle around everything?
+    <mat-datepicker-toggle matSuffix [for]="picker">
+      <mat-icon matDatepickerToggleIcon>keyboard_arrow_down</mat-icon>
+    </mat-datepicker-toggle>
+    <mat-date-range-picker #picker></mat-date-range-picker>
+  </mat-form-field> -->
+
   <button mat-raised-button color="primary" (click)="handleDownload()" [disabled]="disableButton">Download</button>
 </div>

--- a/src/app/modules/routes/pages/route-records/route-records.component.scss
+++ b/src/app/modules/routes/pages/route-records/route-records.component.scss
@@ -7,8 +7,6 @@ button {
   margin: 10px;
   padding-top: 20px;
   text-align: center;
-  // height: 100%;
-  // overflow-y: hidden;
 }
 
 #route-records-wrapper > p {

--- a/src/app/modules/routes/pages/route-records/route-records.component.ts
+++ b/src/app/modules/routes/pages/route-records/route-records.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FbFunctionsService } from 'src/app/modules/backend/services/implementations/firebase';
+import { DateTime } from 'luxon';
 
 @Component({
   selector: 'app-route-records',
@@ -20,8 +21,10 @@ export class RouteRecordsComponent implements OnInit {
 
   handleDownload(): void {
     this.disableButton = true;
-    // turn start and end date into UNIX timestamp, then send to getRouteRecords
-    this.fbFunctionsService.getRouteRecords(this.startDate, this.endDate)
+    // turn start and end date into beginning and end of day, respectively, then send to getRouteRecords
+    const start = DateTime.fromJSDate(this.startDate).startOf('day').toJSDate();
+    const end = DateTime.fromJSDate(this.endDate).endOf('day').toJSDate();
+    this.fbFunctionsService.getRouteRecords(start, end)
       .then((res) => {
         if (res.ok) {
           return res.blob();

--- a/src/app/modules/routes/pages/route-records/route-records.component.ts
+++ b/src/app/modules/routes/pages/route-records/route-records.component.ts
@@ -8,6 +8,8 @@ import { FbFunctionsService } from 'src/app/modules/backend/services/implementat
 })
 export class RouteRecordsComponent implements OnInit {
 
+  public startDate: Date = new Date();
+  public endDate: Date = new Date();;
   public disableButton = false;
 
   constructor(
@@ -18,7 +20,8 @@ export class RouteRecordsComponent implements OnInit {
 
   handleDownload(): void {
     this.disableButton = true;
-    this.fbFunctionsService.getRouteRecords()
+    // turn start and end date into UNIX timestamp, then send to getRouteRecords
+    this.fbFunctionsService.getRouteRecords(this.startDate, this.endDate)
       .then((res) => {
         if (res.ok) {
           return res.blob();

--- a/src/app/modules/routes/pages/route-records/route-records.component.ts
+++ b/src/app/modules/routes/pages/route-records/route-records.component.ts
@@ -1,15 +1,21 @@
 import { Component, OnInit } from '@angular/core';
 import { FbFunctionsService } from 'src/app/modules/backend/services/implementations/firebase';
 import { DateTime } from 'luxon';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
 
 @Component({
   selector: 'app-route-records',
   templateUrl: './route-records.component.html',
-  styleUrls: ['./route-records.component.scss']
+  styleUrls: ['./route-records.component.scss'],
+  providers: [
+    MatDatepickerModule,
+    MatNativeDateModule,
+  ]
 })
 export class RouteRecordsComponent implements OnInit {
 
-  public startDate: Date = new Date();
+  public startDate: Date = DateTime.fromJSDate(new Date()).minus({ days: 7 }).toJSDate();
   public endDate: Date = new Date();;
   public disableButton = false;
 

--- a/src/app/modules/routes/routes.module.ts
+++ b/src/app/modules/routes/routes.module.ts
@@ -19,6 +19,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDividerModule } from '@angular/material/divider'
 import { MatCardModule } from '@angular/material/card';
 import { MatSelectModule } from '@angular/material/select';
+// import { MatDatepickerModule } from '@angular/material/datepicker';
 
 @NgModule({
   declarations: [
@@ -36,6 +37,7 @@ import { MatSelectModule } from '@angular/material/select';
     MatDialogModule,
     MatButtonModule,
     MatCheckboxModule,
+    // MatDatepickerModule,
     MatIconModule,
     MatFormFieldModule,
     MatCardModule,

--- a/src/app/modules/routes/routes.module.ts
+++ b/src/app/modules/routes/routes.module.ts
@@ -14,12 +14,13 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDividerModule } from '@angular/material/divider'
 import { MatCardModule } from '@angular/material/card';
 import { MatSelectModule } from '@angular/material/select';
-// import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
 
 @NgModule({
   declarations: [
@@ -37,7 +38,8 @@ import { MatSelectModule } from '@angular/material/select';
     MatDialogModule,
     MatButtonModule,
     MatCheckboxModule,
-    // MatDatepickerModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
     MatIconModule,
     MatFormFieldModule,
     MatCardModule,
@@ -46,7 +48,9 @@ import { MatSelectModule } from '@angular/material/select';
     MatDividerModule,
     ReactiveFormsModule,
     ExtraMaterialModule,
-    SharedModule
-  ]
+    SharedModule,
+    FormsModule
+  ],
+  providers: []
 })
 export class RoutesModule { }


### PR DESCRIPTION
Implements date selection ranges for getting records. Implemented for both checkin records and route records.

Also fixes a bug that caused record downloads to have incorrect datetimes strings. This was due to Date objects being added to the Excel sheet; the `xlsx` plugin presumably converts them to datetime strings using the machine's local timezone, which in Cloud Functions's case isn't Eastern. We now add correctly formatted datetime strings instead of letting `xlsx` handle Date objects.

## How to test
1. Install new dependencies with `npm i`
1. Run the app with `npm start`
2. Navigate to http://localhost:4200 in a web browser
3. Verify that the "Route Records" page works as intended
  1. verify no bugs in browser console
  2. verify that retrieved records are in the correct range
1. Verify that the "Checkin Records" page works as intended (this page has an extra "View" feature"