### PR TITLE
Set up development environment based on Firebase emulators

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -7,5 +7,8 @@
         ]
       }
     }
+  },
+  "projects": {
+    "default": "gt-recycling"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,6 @@ testem.log
 .DS_Store
 Thumbs.db
 
+firebase-debug.log
 firestore-debug.log
 ui-debug.log

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is part of a suite of apps made for Georgia Tech's [OSWM&R](http://www.recy
 
 Until you add credentials, the project will not run, and there will be an error about missing imports. Credentials are required for both development and deployment.
 
-1. Go to our [Firebase console](https://console.firebase.google.com/u/0/project/gt-recycling/settings/general/)
+1. Go to our [Firebase console settings](https://console.firebase.google.com/u/0/project/gt-recycling/settings/general/)
 1. Retrieve the code for the Firebase config object (Your Apps -> Web apps -> Admin website -> Firebase SDK Snippet -> Config)
 1. Make a new file called `firebase.ts` and place it in the `src/environments` directory, and export the Firebase config object as `default`
    1. A template, `src/environments/firebase-template.ts`, is provided as a reference for this step. This file doesn't do anything else.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ This project uses Firebase services: Authentication, Firestore, and Functions.
 To run locally for development:
 
 1. In a CLI, install dependencies with `npm i`
-1. Run `npm start`
+   1. Also navigate to the `functions` folder to install Firebase functions dependencies: `cd functions`, `npm i`
+1. Go back to the project root directory and run `npm start`
    1. This will start a local development instance. In a web browser, navigate to http://localhost:4200/ to view
    1. This also starts the [Firebase emulators](https://firebase.google.com/docs/emulator-suite). The website mostly uses emulated resources during development instead of production data.
       1. Firestore and Functions are emulated. Authentication uses production auth data, and is not emulated due to lack of need. 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This is part of a suite of apps made for Georgia Tech's [OSWM&R](http://www.recy
 * [route-recorder](https://github.com/dscgt/route_recorder): Buddy app for recycling department crewmembers working recycling routes
 * [recycling-checkin](https://github.com/dscgt/recycling_checkin): Daily check-out/check-in for recycling department crewmembers needing GT property
 
-## Prerequisites for developers
+## For Developers
+
+### Prerequisites
 
 * latest stable version of [Node](https://nodejs.org/en/)
 * latest stable version of NPM (usually included with the Node installation)
@@ -15,79 +17,73 @@ This is part of a suite of apps made for Georgia Tech's [OSWM&R](http://www.recy
 * access to our Firebase console
 * read/write access to this Github repo
 * read/write access to our [private Github repo](https://github.gatech.edu/dscgt/recycling_website_dist)
+* credentials (see below)
 
-## Getting your credentials
+### Getting your credentials
 
 Until you add credentials, the project will not run, and there will be an error about missing imports. Credentials are required for both development and deployment.
 
 1. Go to our [Firebase console](https://console.firebase.google.com/u/0/project/gt-recycling/settings/general/)
 1. Retrieve the code for the Firebase config object (Your Apps -> Web apps -> Admin website -> Firebase SDK Snippet -> Config)
-1. Make a new file called `firebase.ts` and place it in the `src/environments` directory, and export this object as default
-   1. A template, `src/environments/firebase-template.ts`, is provided as a reference for this step.
+1. Make a new file called `firebase.ts` and place it in the `src/environments` directory, and export the Firebase config object as `default`
+   1. A template, `src/environments/firebase-template.ts`, is provided as a reference for this step. This file doesn't do anything else.
 
-It is [not necessary](https://firebase.google.com/docs/projects/api-keys) to secure Firebase API keys like this, but we do so as an extra layer of security. 
+It is [not necessary to secure Firebase API keys](https://firebase.google.com/docs/projects/api-keys) like this, but we do so as an extra layer of security. 
 
-## Running this code
+### Running this code
 
-After getting your credentials (see section above), this code can be run locally for development:
+This project uses Firebase services: Authentication, Firestore, and Functions. 
+
+To run locally for development:
 
 1. In a CLI, install dependencies with `npm i`
-1. Start a local instance with `npm start`
-1. In a web browser, navigate to `localhost:4200` to browse the local instance
+1. Run `npm start`
+   1. This will start a local development instance. In a web browser, navigate to http://localhost:4200/ to view
+   1. This also starts the [Firebase emulators](https://firebase.google.com/docs/emulator-suite). The website mostly uses emulated resources during development instead of production data.
+      1. Firestore and Functions are emulated. Authentication uses production auth data, and is not emulated due to lack of need. 
+      1. Firestore Rules are not emulated, so be mindful when testing new changes.
+      1. If you need the emulated database to contain record data, there are two Functions endpoints (`seedRouteRecords` and `seedCheckinRecords`) to help you by seeding some data.
+      2. A Firebase Hosting version of our website is emulated, at http://localhost:5000/. It may behave unexpectedly, so use the 4200 website instead. For some reason, this can't be shut this off, but we can just ignore it.
 
-## Deploying this code
+### Deploying this code
 
-### To deploy to private instance:
+#### To deploy the website
 
-This uses [Angular's Github Pages deploy](https://npmjs.org/package/angular-cli-ghpages) tool.
+This uses [Angular's Github Pages deploy](https://npmjs.org/package/angular-cli-ghpages) tool, and deploys built files to a private Github Pages instance.
 
 1. Run `ng deploy --base-href=/pages/dscgt/recycling_website_dist/ --repo=https://github.gatech.edu/dscgt/recycling_website_dist.git --branch=master --name="your_gatech_display_name_here" --email="your_gatech_email_here"`
-  1. Build is part of deploy process; no need to build (as in, run `npm run build-prod`) beforehand.
 1. View our deploy [here](https://github.gatech.edu/pages/dscgt/recycling_website_dist/).
 
-### To deploy to public website (LEGACY):
+There is no need to build beforehand, this is done automatically.
 
-We use `@angular/fire`'s [deploy process](https://github.com/angular/angularfire/blob/HEAD/docs/deploy/getting-started.md).
-
-1. In `angular.json`, replace the line `"builder": "@angular/fire:deploy",` with `"builder": "angular-cli-ghpages:deploy",`
-1. If you haven't already, log in to your Firebase account with the Firebase CLI: `firebase login`
-1. Select the `gt-recycling` project
-1. Deploy the app with `ng run recycling-frontend:deploy`
-  1. Build is part of deploy process; no need to build beforehand.
-
-## About
-Made by the [Developer Student Club at Georgia Tech](https://dscgt.club/). 
-
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 9.0.3.
-
-## Other Commands
-
-### Deploy Firebase functions
+#### To deploy Firebase functions
 ```
 firebase deploy --only functions:functionname1,functions:functionname2
 ```
 
-For example, `firebase deploy --only functions:generateExcelSheet` will deploy only the generateExcelSheet() function. 
+For example, `firebase deploy --only functions:generateExcelSheet` will deploy only the generateExcelSheet() endpoint. 
 
-More information:
-https://firebase.google.com/docs/functions/manage-functions#deploy_functions
+More information: \
+https://firebase.google.com/docs/functions/manage-functions#deploy_functions \
 https://firebase.google.com/docs/cli#deploy_specific_functions
 
-### Start Firebase emulators (Functions, Firestore, Hosting).
-Due to how the project is set up, the emulated website (Hosting) will use the production Firestore instance, but emulated Functions will use the emulated Firestore instance.
+### Building this code
 
-1. If you haven't already, log in to your Firebase account with the Firebase CLI: `firebase login`
-2. `firebase emulators:start`
+You shouldn't have to do this that often (or at all), since both running for development and deploying to production build automatically.
 
-More information:
-https://firebase.google.com/docs/emulator-suite
+Building for production:
 
-### Build the webapp
 ```
 npm run build-prod
 ```
-Built files will be placed in a `/dist` directory.
-If building for development (you shouldn't have to do this often or at all, since `npm start` starts a dev environment for you), use:
+
+Building for development:
 ```
 npm run build
 ```
+
+Built files are placed in a `/dist` directory.
+
+## About
+
+Made by the [Developer Student Club at Georgia Tech](https://dscgt.club/). 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ After getting your credentials (see section above), this code can be run locally
 This uses [Angular's Github Pages deploy](https://npmjs.org/package/angular-cli-ghpages) tool.
 
 1. Run `ng deploy --base-href=/pages/dscgt/recycling_website_dist/ --repo=https://github.gatech.edu/dscgt/recycling_website_dist.git --branch=master --name="your_gatech_display_name_here" --email="your_gatech_email_here"`
-  1. Build is part of deploy process; no need to build beforehand.
+  1. Build is part of deploy process; no need to build (as in, run `npm run build-prod`) beforehand.
 1. View our deploy [here](https://github.gatech.edu/pages/dscgt/recycling_website_dist/).
 
 ### To deploy to public website (LEGACY):
@@ -84,10 +84,10 @@ https://firebase.google.com/docs/emulator-suite
 
 ### Build the webapp
 ```
-npm run build
+npm run build-prod
 ```
 Built files will be placed in a `/dist` directory.
-If building for production, use the `--prod` flag:
+If building for development (you shouldn't have to do this often or at all, since `npm start` starts a dev environment for you), use:
 ```
-npm run build --prod
+npm run build
 ```

--- a/firebase.json
+++ b/firebase.json
@@ -29,9 +29,6 @@
     "firestore": {
       "port": 8080
     },
-    "hosting": {
-      "port": 5000
-    },
     "ui": {
       "enabled": true
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2819,6 +2819,12 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.12.tgz",
       "integrity": "sha512-UwfL2uIU9arX/+/PRcIkT08/iBadGN2z6ExOROA2Dh5mAuWTBj6iJbQX4nekiV5H8cTrEG569LeX+HRco9Cbxw=="
     },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -5027,6 +5033,134 @@
         "typedarray": "^0.0.6"
       }
     },
+    "concurrently": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-6.0.0.tgz",
+      "integrity": "sha512-Ik9Igqnef2ONLjN2o/OVx1Ow5tymVvvEwQeYCQdD/oV+CN9oWhxLk7ibcBdOtv0UzBqHCEKRwbKceYoTK8t3fQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "date-fns": "^2.16.1",
+        "lodash": "^4.17.20",
+        "read-pkg": "^5.2.0",
+        "rxjs": "^6.6.3",
+        "spawn-command": "^0.0.2-1",
+        "supports-color": "^8.1.0",
+        "tree-kill": "^1.2.2",
+        "yargs": "^16.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.6",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.6.tgz",
+          "integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==",
+          "dev": true
+        }
+      }
+    },
     "configstore": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
@@ -5785,6 +5919,12 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "date-fns": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.18.0.tgz",
+      "integrity": "sha512-NYyAg4wRmGVU4miKq5ivRACOODdZRY3q5WLmOJSq8djyzftYphU7dTHLcEtLqEvfqMKQ0jVv91P4BAwIjsXIcw==",
+      "dev": true
     },
     "date-format": {
       "version": "3.0.0",
@@ -14145,6 +14285,38 @@
         }
       }
     },
+    "read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "requires": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
+      }
+    },
     "readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -15660,6 +15832,12 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
+    "spawn-command": {
+      "version": "0.0.2-1",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
+      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
       "dev": true
     },
     "spdx-correct": {

--- a/package.json
+++ b/package.json
@@ -2,12 +2,15 @@
   "name": "recycling-frontend",
   "version": "0.0.0",
   "scripts": {
-    "ng": "ng",
-    "start": "ng serve",
     "build": "ng build",
-    "test": "ng test",
+    "build-prod": "ng build --prod",
+    "dev": "ng serve",
+    "e2e": "ng e2e",
+    "emulate": "firebase emulators:start",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "ng": "ng",
+    "start": "concurrently \"npm run dev\" \"npm run emulate\"",
+    "test": "ng test"
   },
   "private": true,
   "dependencies": {
@@ -38,8 +41,9 @@
     "@types/jasminewd2": "~2.0.3",
     "@types/luxon": "^1.25.0",
     "@types/node": "^12.12.54",
-    "codelyzer": "^6.0.0",
     "angular-cli-ghpages": "^1.0.0-rc.1",
+    "codelyzer": "^6.0.0",
+    "concurrently": "^6.0.0",
     "firebase-tools": "^8.9.2",
     "fuzzy": "^0.1.3",
     "inquirer": "^6.2.2",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,6 +12,8 @@ import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { FormsModule } from '@angular/forms';
+import { USE_EMULATOR as USE_FIRESTORE_EMULATOR } from '@angular/fire/firestore';
+import { USE_EMULATOR as USE_FUNCTIONS_EMULATOR } from '@angular/fire/functions';
 
 // Firebase tooling
 import { AngularFireModule } from '@angular/fire';
@@ -54,7 +56,10 @@ import { AdminAccessComponent } from './core/pages/admin-access/admin-access.com
     // DON'T include AngularFireAuth here, or it causes an error
     // https://github.com/angular/angularfire/issues/2351
   ],
-  providers: [],
+  providers: [
+    { provide: USE_FIRESTORE_EMULATOR, useValue: environment.useEmulators ? ['localhost', 8080] : undefined },
+    { provide: USE_FUNCTIONS_EMULATOR, useValue: environment.useEmulators ? ['localhost', 5001] : undefined },
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,7 +2,6 @@ import firebaseConfig from './firebase';
 
 export const environment = {
   production: true,
-
-  // the next line is a TEMPORARY solution -- awaiting true prod environment
+  useEmulators: false,
   firebase: firebaseConfig
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,6 +6,7 @@ import firebaseConfig from './firebase';
 
 export const environment = {
   production: false,
+  useEmulators: true,
   firebase: firebaseConfig
 };
 


### PR DESCRIPTION
Working in development no longer uses the production Firestore and Functions instances. 

Overhauls the README documentation.

## How to test
1. Install new dependencies with `npm i`
1. Run the app with `npm start`
2. Read the entire README, and make sure it makes sense
3. Experiment with the Firebase emulators console
4. Make some changes to the website, and ensure these changes show up only in the emulator
